### PR TITLE
Changes in Api Presenter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+* Service of type Tomaj\NetteApi\Misc\IpDetectorInterface is no more required if service of type Tomaj\NetteApi\Logger\ApiLoggerInterface is not configured and used
+* Service of type Tomaj\NetteApi\Logger\ApiLoggerInterface need not be named "apiLogger"
+
 ## 1.6.0 - 2016-05-11
 
 ### Added

--- a/tests/Presenters/ApiPresenterTest.php
+++ b/tests/Presenters/ApiPresenterTest.php
@@ -27,7 +27,7 @@ class ApiPresenterTest extends PHPUnit_Framework_TestCase
 
         $presenter = new ApiPresenter();
         $presenter->apiDecider = $apiDecider;
-        $presenter->injectPrimary(new Container(), null, null, $httpRequest = new HttpRequest(new UrlScript('')), new HttpResponse());
+        $presenter->injectPrimary(new Container(), null, null, new HttpRequest(new UrlScript('')), new HttpResponse());
 
         $request = new Request('Api:Api:default', 'GET', ['version' => 1, 'package' => 'test', 'apiAction' => 'api']);
         $result = $presenter->run($request);
@@ -49,7 +49,7 @@ class ApiPresenterTest extends PHPUnit_Framework_TestCase
 
         $presenter = new ApiPresenter();
         $presenter->apiDecider = $apiDecider;
-        $presenter->injectPrimary(new Container(), null, null, $httpRequest = new HttpRequest(new UrlScript('')), new HttpResponse());
+        $presenter->injectPrimary(new Container(), null, null, new HttpRequest(new UrlScript('')), new HttpResponse());
 
         $request = new Request('Api:Api:default', 'GET', ['version' => 1, 'package' => 'test', 'apiAction' => 'api']);
         $result = $presenter->run($request);
@@ -69,7 +69,7 @@ class ApiPresenterTest extends PHPUnit_Framework_TestCase
 
         $presenter = new ApiPresenter();
         $presenter->apiDecider = $apiDecider;
-        $presenter->injectPrimary(new Container(), null, null, $httpRequest = new HttpRequest(new UrlScript('')), new HttpResponse());
+        $presenter->injectPrimary(new Container(), null, null, new HttpRequest(new UrlScript('')), new HttpResponse());
 
         $request = new Request('Api:Api:default', 'GET', ['version' => 1, 'package' => 'test', 'apiAction' => 'api']);
         $result = $presenter->run($request);


### PR DESCRIPTION
- Service of type Tomaj\NetteApi\Misc\IpDetectorInterface is no more required if service of type Tomaj\NetteApi\Logger\ApiLoggerInterface is not configured and used
- Service of type Tomaj\NetteApi\Logger\ApiLoggerInterface need not be named "apiLogger"

@tomaj 