### PR TITLE
End of support for php < 5.6 and updated libs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: php
 services:
 
 php:
-    - 5.4
-    - 5.5
     - 5.6
     - 7.0
     - hhvm
@@ -14,7 +12,6 @@ sudo: false
 matrix:
     allow_failures:
         - php: hhvm
-        - php: 7.0
 
 before_script:
     - travis_retry composer self-update
@@ -27,4 +24,4 @@ script:
 
 after_script:
     - wget https://scrutinizer-ci.com/ocular.phar
-    - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != '7.0' ]]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
+    - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+* End of support for php < 5.6
+
 ## 1.6.0 - 2016-05-11
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -11,17 +11,17 @@
         }
     ],
     "require": {
-        "php": ">= 5.4.0",
+        "php": ">= 5.6.0",
         "nette/application": "^2.3.12",
         "nette/http": "^2.0",
         "tracy/tracy": "^2.0",
-        "league/fractal": "^0.12.0",
+        "league/fractal": "^0.13.0",
         "tomaj/nette-bootstrap-form": "^1.1"
     },
     "require-dev": {
         "nette/di": "^2.0",
-        "phpunit/phpunit": "~4.3",
-        "squizlabs/php_codesniffer": "2.*"
+        "phpunit/phpunit": "^5.3",
+        "squizlabs/php_codesniffer": "^2.6"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Params/ParamsProcessorTest.php
+++ b/tests/Params/ParamsProcessorTest.php
@@ -19,15 +19,15 @@ class ParamsProcessorTest extends PHPUnit_Framework_TestCase
 
     public function testPass()
     {
+        $_POST['mykey1'] = 'hello';
+        $_GET['mykey2'] = 'asdasd';
+        $_POST['mykey3'] = 'asd';
+
         $processor = new ParamsProcessor([
             new InputParam(InputParam::TYPE_POST, 'mykey1', InputParam::REQUIRED),
             new InputParam(InputParam::TYPE_GET, 'mykey2', InputParam::REQUIRED),
             new InputParam(InputParam::TYPE_POST, 'mykey3', InputParam::OPTIONAL),
         ]);
-
-        $_POST['mykey1'] = 'hello';
-        $_GET['mykey2'] = 'asdasd';
-        $_POST['mykey3'] = 'asd';
 
         $this->assertFalse($processor->isError());
 


### PR DESCRIPTION
php 5.3 and 5.4 are not already supported and php 5.5 security support ends on 10 Jul 2016 (http://php.net/supported-versions.php), so there is no reason to support these versions in libraries.

@tomaj 