### PR TITLE
Removed deprecated names of components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+* Removed names of components because of commit in nette/component-model (https://github.com/nette/component-model/commit/1fb769f4602cf82694941530bac1111b3c5cd11b)
+
 ## 1.13.1 - 2018-03-16
 
 ### Fixed

--- a/src/Component/ApiConsoleControl.php
+++ b/src/Component/ApiConsoleControl.php
@@ -26,7 +26,7 @@ class ApiConsoleControl extends Control
 
     public function __construct(Request $request, EndpointIdentifier $endpoint, ApiHandlerInterface $handler, ApiAuthorizationInterface $authorization)
     {
-        parent::__construct(null, 'apiconsolecontrol');
+        parent::__construct();
         $this->endpoint = $endpoint;
         $this->handler = $handler;
         $this->authorization = $authorization;

--- a/src/Component/ApiListingControl.php
+++ b/src/Component/ApiListingControl.php
@@ -19,10 +19,9 @@ class ApiListingControl extends Control
 
     public function __construct(IContainer $parent, $name, ApiDecider $apiDecider)
     {
-        parent::__construct(null, $name);
+        parent::__construct();
         $this->apiDecider = $apiDecider;
     }
-
 
     public function onClick(Closure $callback)
     {


### PR DESCRIPTION
because of commit in nette/component-model (https://github.com/nette/component-model/commit/1fb769f4602cf82694941530bac1111b3c5cd11b)