### PR TITLE
Schema validation for all inputs

### DIFF
--- a/src/Params/ParamInterface.php
+++ b/src/Params/ParamInterface.php
@@ -33,7 +33,10 @@ interface ParamInterface
      */
     public function getExample();
 
-    public function getValue();
+    /**
+     * @return mixed
+     */
+    public function value();
 
     public function updateConsoleForm(Form $form): void;
 }

--- a/src/Params/ParamsProcessor.php
+++ b/src/Params/ParamsProcessor.php
@@ -37,7 +37,7 @@ class ParamsProcessor
     {
         $result = [];
         foreach ($this->params as $param) {
-            $result[$param->getKey()] = $param->getValue();
+            $result[$param->getKey()] = $param->value();
         }
 
         return $result;

--- a/tests/Params/ConsoleParamsTest.php
+++ b/tests/Params/ConsoleParamsTest.php
@@ -2,17 +2,14 @@
 
 namespace Tomaj\NetteApi\Test\Params;
 
-use Exception;
 use Nette\Application\UI\Form;
 use Nette\Forms\Controls\BaseControl;
 use PHPUnit\Framework\TestCase;
-use Tomaj\NetteApi\Params\CookieInputParam;
 use Tomaj\NetteApi\Params\FileInputParam;
 use Tomaj\NetteApi\Params\GetInputParam;
 use Tomaj\NetteApi\Params\JsonInputParam;
 use Tomaj\NetteApi\Params\ParamInterface;
 use Tomaj\NetteApi\Params\PostInputParam;
-use Tomaj\NetteApi\Params\PutInputParam;
 use Tomaj\NetteApi\Params\RawInputParam;
 
 class ConsoleParamsTest extends TestCase

--- a/tests/Params/ParamsProcessorTest.php
+++ b/tests/Params/ParamsProcessorTest.php
@@ -17,7 +17,7 @@ class ParamsProcessorTest extends TestCase
         ]);
 
         $this->assertTrue($processor->isError());
-        $this->assertEquals(['mykey1' => ['Field is required']], $processor->getErrors());
+        $this->assertEquals(['mykey1' => ['NULL value found, but a string is required']], $processor->getErrors());
 
         $_GET['mykey2'] = 'x';
         $processor = new ParamsProcessor([
@@ -25,7 +25,7 @@ class ParamsProcessorTest extends TestCase
         ]);
 
         $this->assertTrue($processor->isError());
-        $this->assertEquals(['mykey2' => ['Field contains not available value(s)']], $processor->getErrors());
+        $this->assertEquals(['mykey2' => ['Does not have a value in the enumeration ["a","b","c"]']], $processor->getErrors());
     }
 
     public function testPass()

--- a/tests/Presenters/ApiPresenterTest.php
+++ b/tests/Presenters/ApiPresenterTest.php
@@ -81,7 +81,7 @@ class ApiPresenterTest extends TestCase
 
         Debugger::enable(true);
         $result = $presenter->run($request);
-        $this->assertEquals(['status' => 'error', 'message' => 'wrong input', 'detail' => ['status' => ['Field is required']]], $result->getPayload());
+        $this->assertEquals(['status' => 'error', 'message' => 'wrong input', 'detail' => ['status' => ['NULL value found, but a string is required', 'Does not have a value in the enumeration ["ok","error"]']]], $result->getPayload());
         $this->assertEquals('application/json', $result->getContentType());
         Debugger::enable(false);
     }


### PR DESCRIPTION
Validacia vsetkych typov fieldov cez json schemu ako je to pri JsonInputParam a pretypovanie inputov podla zadaneho typu.

Motivacia:
Vsetky getove / postove parametre pridu ako string (pripadne pole stringov ak mame multi) a nie je ich teda mozne validovat voci nejakemu inemu typu (integer, boolean).

S touto zmenou by sme mohli spravit nieco taketo:
```
public function params(): array
{
    return [
        new GetInputParam('test', '{"param1": "boolean"}'),
        new PostInputParam('test', '{"param2": "integer"}'),
    ];
}
```

Vysledkom by bolo ze ak by sme do param1 dali inu hodnotu ako 1 alebo 0, dostali by sme error, taktiez ak by sme do param2 zadali napr. nejaky string.

Druhou vyhodou by bolo ze v handle metode by uz tieto parametre prisli pretypovane, cize namiesto 1 / 0 pre param1 by uz prisiel true / false a pre param2 by prisiel integer namiesto stringovej reprezentacie integera.

Teoreticky by sa pomocou schemy dali zahodit metody setRequired (nahradi typ not null), setMulti (nahradi typ array) aj setAvailableValues (nahradi enum)

Defaultna schema pre parametre je spatne kompatibilna s aktualnym stavom kedze je tam {"type": "string"} a po zavolani setMulti sa zmeni na {"type": "array"}

V neposlednom rade by sa dala pomocou toho generovat dokumentacia O:-)