### PR TITLE
Fixed return types for ConsoleRequest::processParam() and ConsoleResponse::getResponseHeaders()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [Unreleased][unreleased]
 
+#### Fixed
+
+* Fixed return types for ConsoleRequest::processParam() and ConsoleResponse::getResponseHeaders()
+
 ## 2.0.0 - 2019-06-12
 
 #### Changed

--- a/src/Misc/ConsoleRequest.php
+++ b/src/Misc/ConsoleRequest.php
@@ -177,9 +177,9 @@ class ConsoleRequest
      * @param string          $key     param key
      * @param mixed           $value   actual value from request
      *
-     * @return string|null
+     * @return mixed
      */
-    private function processParam(ParamInterface $param, string $key, $value): ?string
+    private function processParam(ParamInterface $param, string $key, $value)
     {
         if ($param->getKey() === $key) {
             $valueData = $value;

--- a/src/Misc/ConsoleResponse.php
+++ b/src/Misc/ConsoleResponse.php
@@ -121,7 +121,7 @@ class ConsoleResponse
         return $body;
     }
 
-    public function getResponseHeaders(): string
+    public function getResponseHeaders(): ?string
     {
         return $this->responseHeaders;
     }


### PR DESCRIPTION
Resolves #74 