### PR TITLE
Fixed static url part `/api/` in console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 * Fixed sending empty string in multi params
 * UrlEncoding values sending through get param inputs
+* Fixed static url part `/api/` in console
 
 ## 2.0.1 - 2020-03-24
 

--- a/README.md
+++ b/README.md
@@ -403,10 +403,13 @@ use Nette\Application\UI\Presenter;
 use Tomaj\NetteApi\ApiDecider;
 use Tomaj\NetteApi\Component\ApiConsoleControl;
 use Tomaj\NetteApi\Component\ApiListingControl;
+use Tomaj\NetteApi\Link\ApiLink;
 
 class MyPresenter extends Presenter
 {
     private $apiDecider;
+
+    private $apiLink;
 
     private $method;
     
@@ -416,10 +419,11 @@ class MyPresenter extends Presenter
     
     private $apiAction;
 
-    public function __construct(ApiDecider $apiDecider)
+    public function __construct(ApiDecider $apiDecider, ApiLink $apiLink = null)
     {
         parent::__construct();
         $this->apiDecider = $apiDecider;
+        $this->apiLink = $apiLink;
     }
 
     public function renderShow(string $method, int $version, string $package, ?string $apiAction = null): void
@@ -441,8 +445,8 @@ class MyPresenter extends Presenter
 
     protected function createComponentApiConsole()
     {
-        $api = $this->apiDecider->getApiHandler($this->method, $this->version, $this->package, $this->apiAction);
-        $apiConsole = new ApiConsoleControl($this->getHttpRequest(), $api->getEndpoint(), $api->getHandler(), $api->getAuthorization());
+        $api = $this->apiDecider->getApi($this->method, $this->version, $this->package, $this->apiAction);
+        $apiConsole = new ApiConsoleControl($this->getHttpRequest(), $api->getEndpoint(), $api->getHandler(), $api->getAuthorization(), $this->apiLink);
         return $apiConsole;
     }
 }


### PR DESCRIPTION
If I register route like this:
```
$router[] = new Route('nette-api/v<version>/<package>[/<apiAction>][/<params>]', 'Api:Api:default');
```
URLs in API console are still `/api/`

ApiLink will fix this issue.

But, it has to be optional, because it would cause BC break - we can change it to required in next major version.