### PR TITLE
Vertical form renderer in API console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [Unreleased][unreleased]
 
+#### Changed
+
+* Form in API console is rendered with BootstrapVerticalRenderer instead of BootstrapRenderer (labels are over fields instead of left side)
+
 #### Added
 
 * Added API key authentication (query, header, cookie) - see https://swagger.io/docs/specification/authentication/api-keys/

--- a/src/Component/ApiConsoleControl.php
+++ b/src/Component/ApiConsoleControl.php
@@ -10,7 +10,7 @@ use Nette\Bridges\ApplicationLatte\Template;
 use Nette\Http\IRequest;
 use Nette\Utils\ArrayHash;
 use Nette\Utils\Html;
-use Tomaj\Form\Renderer\BootstrapRenderer;
+use Tomaj\Form\Renderer\BootstrapVerticalRenderer;
 use Tomaj\NetteApi\Authorization\ApiAuthorizationInterface;
 use Tomaj\NetteApi\Authorization\BasicAuthentication;
 use Tomaj\NetteApi\Authorization\BearerTokenAuthorization;
@@ -59,7 +59,7 @@ class ApiConsoleControl extends Control
 
         $defaults = [];
 
-        $form->setRenderer(new BootstrapRenderer());
+        $form->setRenderer(new BootstrapVerticalRenderer());
 
         if ($this->apiLink) {
             $url = $this->apiLink->link($this->endpoint);


### PR DESCRIPTION
Form in API console is rendered with BootstrapVerticalRenderer instead of BootstrapRenderer (labels are over fields instead of left side)