### PR TITLE
Added additonal data for API handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [Unreleased][unreleased]
 
+#### Added
+
+* Added additonal data for API handlers
+
 ## 2.4.0 - 2021-04-24
 
 #### Added

--- a/src/Handlers/ApiHandlerInterface.php
+++ b/src/Handlers/ApiHandlerInterface.php
@@ -68,4 +68,11 @@ interface ApiHandlerInterface
      * @return OutputInterface[]
      */
     public function outputs(): array;
+
+    /**
+     * List of additional information for handler
+     *
+     * @return array<string, int|string|bool|array>
+     */
+    public function additionalData(): array;
 }

--- a/src/Handlers/BaseHandler.php
+++ b/src/Handlers/BaseHandler.php
@@ -82,6 +82,11 @@ abstract class BaseHandler implements ApiHandlerInterface
         return [];
     }
 
+    public function additionalData(): array
+    {
+        return [];
+    }
+
     protected function getFractal(): Manager
     {
         if (!$this->fractal) {

--- a/src/Handlers/OpenApiHandler.php
+++ b/src/Handlers/OpenApiHandler.php
@@ -310,6 +310,10 @@ class OpenApiHandler extends BaseHandler
                 'tags' => $handler->tags(),
             ];
 
+            foreach ($handler->additionalData() as $additionalDataKey => $additionalDataValue) {
+                $settings['x-' . $additionalDataKey] = $additionalDataValue;
+            }
+
             if ($handler->deprecated()) {
                 $settings['deprecated'] = true;
             }


### PR DESCRIPTION
Usage example:
```
    public function additionalData(): array
    {
        return [
            'skip' => true,
            'some-number' => 42,
            'test' => 'this is test',
            'run-before' => [
                'first',
                'second',
                'third',
            ],
        ];
    }
```

Will generate this output in OpenApi:
<img width="1626" alt="Screenshot 2021-05-11 at 00 58 47" src="https://user-images.githubusercontent.com/9377319/117735032-faa22900-b1f4-11eb-989c-ebc1c52dba9a.png">
