### PR TITLE
Use relaxed TokenRepositoryInterface in BearerTokenAuthorization

### DIFF
--- a/src/Authorization/BearerTokenAuthorization.php
+++ b/src/Authorization/BearerTokenAuthorization.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 
 namespace Tomaj\NetteApi\Authorization;
 
-use Tomaj\NetteApi\Misc\BearerTokenRepositoryInterface;
 use Tomaj\NetteApi\Misc\IpDetectorInterface;
+use Tomaj\NetteApi\Misc\TokenRepositoryInterface;
 
 class BearerTokenAuthorization extends TokenAuthorization
 {
    /**
      * BearerTokenAuthorization constructor.
      *
-     * @param BearerTokenRepositoryInterface $tokenRepository
-     * @param IpDetectorInterface            $ipDetector
+     * @param TokenRepositoryInterface $tokenRepository
+     * @param IpDetectorInterface      $ipDetector
      */
-    public function __construct(BearerTokenRepositoryInterface $tokenRepository, IpDetectorInterface $ipDetector)
+    public function __construct(TokenRepositoryInterface $tokenRepository, IpDetectorInterface $ipDetector)
     {
         parent::__construct($tokenRepository, $ipDetector);
     }

--- a/src/Authorization/TokenAuthorization.php
+++ b/src/Authorization/TokenAuthorization.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tomaj\NetteApi\Authorization;
 
-use Tomaj\NetteApi\Misc\BearerTokenRepositoryInterface;
 use Tomaj\NetteApi\Misc\IpDetectorInterface;
 use Tomaj\NetteApi\Misc\TokenRepositoryInterface;
 


### PR DESCRIPTION
The deprecation of `BearerTokenRepositoryInterface` in favor of
TokenRepositoryInterface requires people implementing the interface
to change their implementation.

However if they do that and swap the interfaces, they can no longer
use `BearerTokenAuthorization` in their API calls. The library is
basically forcing everyone to keep using deprecated interface.

This commit fixes the issue and allows to use more relaxed
`TokenRepositoryInterface` in `BearerTokenAuthorization`. This is backwards
compatible change, because anyone implementing `BearerTokenRepositoryInterface`
is already implementing `TokenRepositoryInterface`.