### PR TITLE
PHP8.1 support (league/fractal upgrade)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 #### Added
 
-* PHP 8.1 support (`league/fractal` 0.20.1) (BC Break)
+* PHP 8.1 support (`league/fractal` 0.20.1)
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [Unreleased][unreleased]
 
+#### Added
+
+* PHP 8.1 support (`league/fractal` 0.21.2) (BC Break)
+
 #### Fixed
 
 * Missing expiration params in XmlApiResponse

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 #### Added
 
-* PHP 8.1 support (`league/fractal` 0.21.2) (BC Break)
+* PHP 8.1 support (`league/fractal` 0.20.1) (BC Break)
 
 #### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "nette/application": "^3.0",
         "nette/http": "^3.0",
         "tracy/tracy": "^2.6",
-        "league/fractal": "^0.17.0",
+        "league/fractal": "^0.17.0 || ^0.20.1",
         "tomaj/nette-bootstrap-form": "^2.0",
         "justinrainbow/json-schema": "^5.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "nette/application": "^3.0",
         "nette/http": "^3.0",
         "tracy/tracy": "^2.6",
-        "league/fractal": "~0.17.0",
+        "league/fractal": "~0.17",
         "tomaj/nette-bootstrap-form": "^2.0",
         "justinrainbow/json-schema": "^5.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "nette/application": "^3.0",
         "nette/http": "^3.0",
         "tracy/tracy": "^2.6",
-        "league/fractal": "^0.17.0 || ^0.20.1",
+        "league/fractal": "~0.17.0",
         "tomaj/nette-bootstrap-form": "^2.0",
         "justinrainbow/json-schema": "^5.2"
     },


### PR DESCRIPTION
This is the only thing stopping our app from having PHP8.1 support. The fork is tested and works, however since the Transformer interface has been changed, BC Break is inevitable.