### PR TITLE
fix null $body for php 8.0

### DIFF
--- a/src/Misc/ConsoleResponse.php
+++ b/src/Misc/ConsoleResponse.php
@@ -114,8 +114,8 @@ class ConsoleResponse
     public function getFormattedJsonBody(): string
     {
         $body = $this->responseBody;
-        if ($body === null){
-            $body = '{}';
+        if ($body === null) {
+            return '';
         }
         $decoded = json_decode($body);
         if ($decoded) {

--- a/src/Misc/ConsoleResponse.php
+++ b/src/Misc/ConsoleResponse.php
@@ -114,7 +114,7 @@ class ConsoleResponse
     public function getFormattedJsonBody(): string
     {
         $body = $this->responseBody;
-        if($body === null){
+        if ($body === null){
             $body = '{}';
         }
         $decoded = json_decode($body);

--- a/src/Misc/ConsoleResponse.php
+++ b/src/Misc/ConsoleResponse.php
@@ -114,6 +114,9 @@ class ConsoleResponse
     public function getFormattedJsonBody(): string
     {
         $body = $this->responseBody;
+        if($body === null){
+            $body = '{}';
+        }
         $decoded = json_decode($body);
         if ($decoded) {
             $body = json_encode($decoded, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);


### PR DESCRIPTION
Fixing $body variable with a null value, for method json_decode in php 8.0