### PR TITLE
Add support for semantic versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
 ## [Unreleased][unreleased]
+#### Changed
+* [BC] Support for semantic versioning api. Need retype version from `int` to `string`.
 
 #### Added
 * CorsPreflightHandlerInterface - resolve multiple service registered handler error

--- a/src/ApiDecider.php
+++ b/src/ApiDecider.php
@@ -26,13 +26,13 @@ class ApiDecider
      * If decider cannot find handler for given handler, returns defaults.
      *
      * @param string   $method
-     * @param integer  $version
+     * @param string   $version
      * @param string   $package
      * @param string   $apiAction
      *
      * @return Api
      */
-    public function getApi(string $method, int $version, string $package, ?string $apiAction = null)
+    public function getApi(string $method, string $version, string $package, ?string $apiAction = null)
     {
         $method = strtoupper($method);
         $apiAction = $apiAction === '' ? null : $apiAction;

--- a/src/EndpointIdentifier.php
+++ b/src/EndpointIdentifier.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tomaj\NetteApi;
 
+use InvalidArgumentException;
+
 class EndpointIdentifier implements EndpointInterface
 {
     private $method;
@@ -14,9 +16,12 @@ class EndpointIdentifier implements EndpointInterface
 
     private $apiAction;
 
-    public function __construct(string $method, int $version, string $package, ?string $apiAction = null)
+    public function __construct(string $method, string $version, string $package, ?string $apiAction = null)
     {
         $this->method = strtoupper($method);
+        if ($this->checkVersionFormat($version) === false) {
+            throw new InvalidArgumentException('Version must have semantic numbering. For example "1", "1.1", "0.13.2" etc.');
+        }
         $this->version = $version;
         $this->package = $package;
         $this->apiAction = $apiAction;
@@ -27,7 +32,7 @@ class EndpointIdentifier implements EndpointInterface
         return $this->method;
     }
 
-    public function getVersion(): int
+    public function getVersion(): string
     {
         return $this->version;
     }
@@ -49,4 +54,10 @@ class EndpointIdentifier implements EndpointInterface
     {
         return "v{$this->version}/{$this->package}/{$this->apiAction}";
     }
+
+    private function checkVersionFormat(string $version): bool
+    {
+        return (preg_match('/^(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*)){0,2}$/', $version) === 1);
+    }
+
 }

--- a/src/EndpointIdentifier.php
+++ b/src/EndpointIdentifier.php
@@ -59,5 +59,4 @@ class EndpointIdentifier implements EndpointInterface
     {
         return (preg_match('/^(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*)){0,2}$/', $version) === 1);
     }
-
 }

--- a/src/EndpointIdentifier.php
+++ b/src/EndpointIdentifier.php
@@ -19,7 +19,7 @@ class EndpointIdentifier implements EndpointInterface
     public function __construct(string $method, string $version, string $package, ?string $apiAction = null)
     {
         $this->method = strtoupper($method);
-        if ($this->checkVersionFormat($version) === false) {
+        if (strpos($version, '/') !== false) {
             throw new InvalidArgumentException('Version must have semantic numbering. For example "1", "1.1", "0.13.2" etc.');
         }
         $this->version = $version;
@@ -53,10 +53,5 @@ class EndpointIdentifier implements EndpointInterface
     public function getUrl(): string
     {
         return "v{$this->version}/{$this->package}/{$this->apiAction}";
-    }
-
-    private function checkVersionFormat(string $version): bool
-    {
-        return (preg_match('/^(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*)){0,2}$/', $version) === 1);
     }
 }

--- a/src/EndpointInterface.php
+++ b/src/EndpointInterface.php
@@ -8,7 +8,7 @@ interface EndpointInterface
 {
     public function getMethod(): string;
 
-    public function getVersion(): int;
+    public function getVersion(): string;
 
     public function getPackage(): string;
 

--- a/src/Handlers/ApiListingHandler.php
+++ b/src/Handlers/ApiListingHandler.php
@@ -53,7 +53,7 @@ class ApiListingHandler extends BaseHandler
      *
      * @return array
      */
-    private function getApiList(int $version): array
+    private function getApiList(string $version): array
     {
         $versionApis = array_filter($this->apiDecider->getApis(), function (Api $api) use ($version) {
             return $version === $api->getEndpoint()->getVersion();

--- a/src/Handlers/OpenApiHandler.php
+++ b/src/Handlers/OpenApiHandler.php
@@ -227,7 +227,7 @@ class OpenApiHandler extends BaseHandler
         return new JsonApiResponse(IResponse::S200_OK, $data);
     }
 
-    private function getApis(int $version): array
+    private function getApis(string $version): array
     {
         return array_filter($this->apiDecider->getApis(), function (Api $api) use ($version) {
             return $version === $api->getEndpoint()->getVersion();

--- a/src/Presenters/ApiPresenter.php
+++ b/src/Presenters/ApiPresenter.php
@@ -142,7 +142,7 @@ final class ApiPresenter implements IPresenter
     {
         return $this->apiDecider->getApi(
             $request->getMethod(),
-            (int) $request->getParameter('version'),
+            $request->getParameter('version'),
             $request->getParameter('package'),
             $request->getParameter('apiAction')
         );

--- a/tests/ApiDeciderTest.php
+++ b/tests/ApiDeciderTest.php
@@ -17,7 +17,7 @@ class ApiDeciderTest extends TestCase
     public function testDefaultHandlerWithNoRegisteredHandlers()
     {
         $apiDecider = new ApiDecider();
-        $result = $apiDecider->getApi('POST', 1, 'article', 'list');
+        $result = $apiDecider->getApi('POST', '1', 'article', 'list');
 
         $this->assertInstanceOf(EndpointIdentifier::class, $result->getEndpoint());
         $this->assertInstanceOf(NoAuthorization::class, $result->getAuthorization());
@@ -28,19 +28,19 @@ class ApiDeciderTest extends TestCase
     {
         $apiDecider = new ApiDecider();
         $apiDecider->addApi(
-            new EndpointIdentifier('POST', 2, 'comments', 'list'),
+            new EndpointIdentifier('POST', '2', 'comments', 'list'),
             new AlwaysOkHandler(),
             new NoAuthorization()
         );
 
-        $result = $apiDecider->getApi('POST', 2, 'comments', 'list');
+        $result = $apiDecider->getApi('POST', '2', 'comments', 'list');
 
         $this->assertInstanceOf(EndpointIdentifier::class, $result->getEndpoint());
         $this->assertInstanceOf(NoAuthorization::class, $result->getAuthorization());
         $this->assertInstanceOf(AlwaysOkHandler::class, $result->getHandler());
 
         $this->assertEquals('POST', $result->getEndpoint()->getMethod());
-        $this->assertEquals(2, $result->getEndpoint()->getVersion());
+        $this->assertEquals('2', $result->getEndpoint()->getVersion());
         $this->assertEquals('comments', $result->getEndpoint()->getPackage());
         $this->assertEquals('list', $result->getEndpoint()->getApiAction());
     }
@@ -52,7 +52,7 @@ class ApiDeciderTest extends TestCase
         $this->assertEquals(0, count($apiDecider->getApis()));
 
         $apiDecider->addApi(
-            new EndpointIdentifier('POST', 2, 'comments', 'list'),
+            new EndpointIdentifier('POST', '2', 'comments', 'list'),
             new AlwaysOkHandler(),
             new NoAuthorization()
         );
@@ -68,14 +68,14 @@ class ApiDeciderTest extends TestCase
         $this->assertEquals(0, count($apiDecider->getApis()));
 
         $apiDecider->addApi(
-            new EndpointIdentifier('POST', 2, 'comments', 'list'),
+            new EndpointIdentifier('POST', '2', 'comments', 'list'),
             new AlwaysOkHandler(),
             new NoAuthorization()
         );
 
         $this->assertEquals(1, count($apiDecider->getApis()));
 
-        $handler = $apiDecider->getApi('OPTIONS', 2, 'comments', 'list');
+        $handler = $apiDecider->getApi('OPTIONS', '2', 'comments', 'list');
         $this->assertInstanceOf(CorsPreflightHandler::class, $handler->getHandler());
     }
 }

--- a/tests/EndpoinIdentifierTest.php
+++ b/tests/EndpoinIdentifierTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tomaj\NetteApi\Test\Params;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Tomaj\NetteApi\EndpointIdentifier;
 
@@ -11,19 +12,42 @@ class EndpointIdentifierTest extends TestCase
 {
     public function testValidation()
     {
-        $endpoint = new EndpointIdentifier('POST', 1, 'core', 'show');
+        $endpoint = new EndpointIdentifier('POST', '1', 'core', 'show');
 
+        $this->assertSame('1', $endpoint->getVersion());
         $this->assertEquals('POST', $endpoint->getMethod());
-        $this->assertEquals(1, $endpoint->getVersion());
         $this->assertEquals('core', $endpoint->getPackage());
         $this->assertEquals('show', $endpoint->getApiAction());
         $this->assertEquals('v1/core/show', $endpoint->getUrl());
+
+        $endpoint = new EndpointIdentifier('POST', '1.1', 'core', 'show');
+        $this->assertEquals('v1.1/core/show', $endpoint->getUrl());
+
+        $endpoint = new EndpointIdentifier('POST', '1.1.2', 'core', 'show');
+        $this->assertEquals('v1.1.2/core/show', $endpoint->getUrl());
     }
 
     public function testSimpleUrl()
     {
-        $endpoint = new EndpointIdentifier('get', 2, 'main', '');
+        $endpoint = new EndpointIdentifier('get', '2', 'main', '');
         $this->assertNull($endpoint->getApiAction());
         $this->assertEquals('GET', $endpoint->getMethod());
+    }
+
+    public function testSupportedVersions()
+    {
+        new EndpointIdentifier('GET', '0', 'core', 'show');
+        new EndpointIdentifier('GET', '1', 'core', 'show');
+        new EndpointIdentifier('GET', '1.0', 'core', 'show');
+        new EndpointIdentifier('GET', '1.1', 'core', 'show');
+        new EndpointIdentifier('GET', '1.33', 'core', 'show');
+        $endpoint = new EndpointIdentifier('GET', '0.33.43', 'core', 'show');
+        $this->assertEquals('v0.33.43/core/show', $endpoint->getUrl());
+    }
+
+    public function testFailVersion()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new EndpointIdentifier('GET', 'test', 'core', 'show');
     }
 }

--- a/tests/EndpoinIdentifierTest.php
+++ b/tests/EndpoinIdentifierTest.php
@@ -36,11 +36,18 @@ class EndpointIdentifierTest extends TestCase
 
     public function testSupportedVersions()
     {
-        new EndpointIdentifier('GET', '0', 'core', 'show');
-        new EndpointIdentifier('GET', '1', 'core', 'show');
-        new EndpointIdentifier('GET', '1.0', 'core', 'show');
-        new EndpointIdentifier('GET', '1.1', 'core', 'show');
-        new EndpointIdentifier('GET', '1.33', 'core', 'show');
+        $endpoint = new EndpointIdentifier('GET', '0', 'core', 'show');
+        $this->assertEquals('v0/core/show', $endpoint->getUrl());
+        $endpoint = new EndpointIdentifier('GET', '1', 'core', 'show');
+        $this->assertEquals('v1/core/show', $endpoint->getUrl());
+        $endpoint = new EndpointIdentifier('GET', '1.0', 'core', 'show');
+        $this->assertEquals('v1.0/core/show', $endpoint->getUrl());
+        $endpoint = new EndpointIdentifier('GET', '1.1', 'core', 'show');
+        $this->assertEquals('v1.1/core/show', $endpoint->getUrl());
+        $endpoint = new EndpointIdentifier('GET', '1.33', 'core', 'show');
+        $this->assertEquals('v1.33/core/show', $endpoint->getUrl());
+        $endpoint = new EndpointIdentifier('GET', '1.33-dev', 'core', 'show');
+        $this->assertEquals('v1.33-dev/core/show', $endpoint->getUrl());
         $endpoint = new EndpointIdentifier('GET', '0.33.43', 'core', 'show');
         $this->assertEquals('v0.33.43/core/show', $endpoint->getUrl());
     }
@@ -48,6 +55,6 @@ class EndpointIdentifierTest extends TestCase
     public function testFailVersion()
     {
         $this->expectException(InvalidArgumentException::class);
-        new EndpointIdentifier('GET', 'test', 'core', 'show');
+        new EndpointIdentifier('GET', '1.0/dev', 'core', 'show');
     }
 }

--- a/tests/Handler/ApiListingHandlerTest.php
+++ b/tests/Handler/ApiListingHandlerTest.php
@@ -25,18 +25,18 @@ class ApiListingHandlerTest extends TestCase
 
         $apiDecider = new ApiDecider();
         $apiDecider->addApi(
-            new EndpointIdentifier('POST', 2, 'comments', 'list'),
+            new EndpointIdentifier('POST', '2', 'comments', 'list'),
             new AlwaysOkHandler(),
             new NoAuthorization()
         );
 
         $apiDecider->addApi(
-            new EndpointIdentifier('GET', 2, 'endpoints'),
+            new EndpointIdentifier('GET', '2', 'endpoints'),
             new ApiListingHandler($apiDecider, $apiLink),
             new NoAuthorization()
         );
 
-        $result = $apiDecider->getApi('GET', 2, 'endpoints');
+        $result = $apiDecider->getApi('GET', '2', 'endpoints');
         $handler = $result->getHandler();
 
         $response = $handler->handle([]);
@@ -52,18 +52,18 @@ class ApiListingHandlerTest extends TestCase
 
         $apiDecider = new ApiDecider();
         $apiDecider->addApi(
-            new EndpointIdentifier('POST', 1, 'comments', 'list'),
+            new EndpointIdentifier('POST', '1', 'comments', 'list'),
             new EchoHandler(),
             new NoAuthorization()
         );
 
         $apiDecider->addApi(
-            new EndpointIdentifier('GET', 1, 'endpoints'),
+            new EndpointIdentifier('GET', '1', 'endpoints'),
             new ApiListingHandler($apiDecider, $apiLink),
             new NoAuthorization()
         );
 
-        $result = $apiDecider->getApi('GET', 1, 'endpoints');
+        $result = $apiDecider->getApi('GET', '1', 'endpoints');
         $handler = $result->getHandler();
 
         $response = $handler->handle([]);

--- a/tests/Handler/CorsPreflightHandlerTest.php
+++ b/tests/Handler/CorsPreflightHandlerTest.php
@@ -28,7 +28,7 @@ class CorsPreflightHandlerTest extends TestCase
         $defaultHandler = new CorsPreflightHandler(new Response());
         $this->assertNull($defaultHandler->getEndpoint());
 
-        $endpointIdentifier = new EndpointIdentifier('OPTIONS', 1, 'article', 'detail');
+        $endpointIdentifier = new EndpointIdentifier('OPTIONS', '1', 'article', 'detail');
         $defaultHandler->setEndpointIdentifier($endpointIdentifier);
         $this->assertEquals($endpointIdentifier, $defaultHandler->getEndpoint());
     }
@@ -61,7 +61,7 @@ class CorsPreflightHandlerTest extends TestCase
         $linkGenerator = new LinkGenerator(new SimpleRouter([]), new UrlScript('http://test/'));
         $defaultHandler->setupLinkGenerator($linkGenerator);
 
-        $endpointIdentifier = new EndpointIdentifier('OPTIONS', 1, 'article', 'detail');
+        $endpointIdentifier = new EndpointIdentifier('OPTIONS', '1', 'article', 'detail');
         $defaultHandler->setEndpointIdentifier($endpointIdentifier);
 
         $this->assertEquals('http://test/?version=1&package=article&apiAction=detail&page=2&action=default&presenter=Api%3AApi', $defaultHandler->createLink(['page' => 2]));

--- a/tests/Handler/DefaultHandlerTest.php
+++ b/tests/Handler/DefaultHandlerTest.php
@@ -29,7 +29,7 @@ class DefaultHandlerTest extends TestCase
         $defaultHandler = new DefaultHandler();
         $this->assertNull($defaultHandler->getEndpoint());
 
-        $endpointIdentifier = new EndpointIdentifier('POST', 1, 'article', 'detail');
+        $endpointIdentifier = new EndpointIdentifier('POST', '1', 'article', 'detail');
         $defaultHandler->setEndpointIdentifier($endpointIdentifier);
         $this->assertEquals($endpointIdentifier, $defaultHandler->getEndpoint());
     }
@@ -62,7 +62,7 @@ class DefaultHandlerTest extends TestCase
         $linkGenerator = new LinkGenerator(new SimpleRouter([]), new UrlScript('http://test/'));
         $defaultHandler->setupLinkGenerator($linkGenerator);
 
-        $endpointIdentifier = new EndpointIdentifier('POST', 1, 'article', 'detail');
+        $endpointIdentifier = new EndpointIdentifier('POST', '1', 'article', 'detail');
         $defaultHandler->setEndpointIdentifier($endpointIdentifier);
 
         $this->assertEquals('http://test/?version=1&package=article&apiAction=detail&page=2&action=default&presenter=Api%3AApi', $defaultHandler->createLink(['page' => 2]));

--- a/tests/Handler/OpenApiHandlerTest.php
+++ b/tests/Handler/OpenApiHandlerTest.php
@@ -25,18 +25,18 @@ class OpenApiHandlerTest extends TestCase
 
         $apiDecider = new ApiDecider();
         $apiDecider->addApi(
-            new EndpointIdentifier('GET', 1, 'test'),
+            new EndpointIdentifier('GET', '1', 'test'),
             new MultipleOutputTestHandler(),
             new NoAuthorization()
         );
 
         $apiDecider->addApi(
-            new EndpointIdentifier('GET', 1, 'docs', 'open-api'),
+            new EndpointIdentifier('GET', '1', 'docs', 'open-api'),
             new OpenApiHandler($apiDecider, $apiLink, $request),
             new NoAuthorization()
         );
 
-        $result = $apiDecider->getApi('GET', 1, 'docs', 'open-api');
+        $result = $apiDecider->getApi('GET', '1', 'docs', 'open-api');
         $handler = $result->getHandler();
 
         $response = $handler->handle(['format' => 'json']);

--- a/tests/Presenters/ApiPresenterTest.php
+++ b/tests/Presenters/ApiPresenterTest.php
@@ -27,14 +27,14 @@ class ApiPresenterTest extends TestCase
     public function testSimpleResponse()
     {
         $apiDecider = new ApiDecider();
-        $apiDecider->addApi(new EndpointIdentifier('GET', 1, 'test', 'api'), new AlwaysOkHandler(), new NoAuthorization());
+        $apiDecider->addApi(new EndpointIdentifier('GET', '1', 'test', 'api'), new AlwaysOkHandler(), new NoAuthorization());
 
         $presenter = new ApiPresenter();
         $presenter->apiDecider = $apiDecider;
         $presenter->response = new HttpResponse();
         $presenter->context = new Container();
 
-        $request = new Request('Api:Api:default', 'GET', ['version' => 1, 'package' => 'test', 'apiAction' => 'api']);
+        $request = new Request('Api:Api:default', 'GET', ['version' => '1', 'package' => 'test', 'apiAction' => 'api']);
         $result = $presenter->run($request);
 
         $this->assertEquals(200, $result->getCode());
@@ -47,7 +47,7 @@ class ApiPresenterTest extends TestCase
     {
         $apiDecider = new ApiDecider();
         $apiDecider->addApi(
-            new EndpointIdentifier('GET', 1, 'test', 'api'),
+            new EndpointIdentifier('GET', '1', 'test', 'api'),
             new AlwaysOkHandler(),
             new BearerTokenAuthorization(new StaticTokenRepository([]), new IpDetector())
         );
@@ -57,7 +57,7 @@ class ApiPresenterTest extends TestCase
         $presenter->response = new HttpResponse();
         $presenter->context = new Container();
 
-        $request = new Request('Api:Api:default', 'GET', ['version' => 1, 'package' => 'test', 'apiAction' => 'api']);
+        $request = new Request('Api:Api:default', 'GET', ['version' => '1', 'package' => 'test', 'apiAction' => 'api']);
         $result = $presenter->run($request);
 
         $this->assertEquals(['status' => 'error', 'message' => 'Authorization header HTTP_Authorization is not set'], $result->getPayload());
@@ -68,7 +68,7 @@ class ApiPresenterTest extends TestCase
     {
         $apiDecider = new ApiDecider();
         $apiDecider->addApi(
-            new EndpointIdentifier('GET', 1, 'test', 'api'),
+            new EndpointIdentifier('GET', '1', 'test', 'api'),
             new EchoHandler(),
             new NoAuthorization()
         );
@@ -80,7 +80,7 @@ class ApiPresenterTest extends TestCase
 
         Debugger::$productionMode = Debugger::PRODUCTION;
 
-        $request = new Request('Api:Api:default', 'GET', ['version' => 1, 'package' => 'test', 'apiAction' => 'api']);
+        $request = new Request('Api:Api:default', 'GET', ['version' => '1', 'package' => 'test', 'apiAction' => 'api']);
         $result = $presenter->run($request);
 
         $this->assertEquals(['status' => 'error', 'message' => 'wrong input'], $result->getPayload());
@@ -97,7 +97,7 @@ class ApiPresenterTest extends TestCase
     {
         $apiDecider = new ApiDecider();
         $apiDecider->addApi(
-            new EndpointIdentifier('GET', 1, 'test', 'api'),
+            new EndpointIdentifier('GET', '1', 'test', 'api'),
             new TestHandler(),
             new NoAuthorization()
         );
@@ -107,7 +107,7 @@ class ApiPresenterTest extends TestCase
         $presenter->response = new HttpResponse();
         $presenter->context = new Container();
 
-        $request = new Request('Api:Api:default', 'GET', ['version' => 1, 'package' => 'test', 'apiAction' => 'api']);
+        $request = new Request('Api:Api:default', 'GET', ['version' => '1', 'package' => 'test', 'apiAction' => 'api']);
         $result = $presenter->run($request);
 
         $this->assertEquals(['hello' => 'world'], $result->getPayload());


### PR DESCRIPTION
If the minimum version of php was increased to `8.0` in `4.0`, it would not be necessary to modify `int` to `string` in the API settings.