### PR TITLE
Lazy api handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 #### Changed
 * Support for semantic versioning api.
 * [BC] DefaultHandler response code 404 instead 400
+* [BC] Added Container to API Decider and API Decider is final
 
 #### Added
 * CorsPreflightHandlerInterface - resolve multiple service registered handler error
+* Lazy API handlers
 
 #### Added
 * Button to copy `Body` content in api console

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 #### Changed
 * Support for semantic versioning api.
 * [BC] DefaultHandler response code 404 instead 400
-* [BC] Added Container to API Decider and API Decider is final
+* [BC] Added Container to API Decider
 
 #### Added
 * CorsPreflightHandlerInterface - resolve multiple service registered handler error

--- a/README.md
+++ b/README.md
@@ -64,13 +64,26 @@ After that you need only register your API handlers to *apiDecider* [ApiDecider]
 
 ```neon
 services:
-  - Tomaj\NetteApi\Link\ApiLink
-  - Tomaj\NetteApi\Misc\IpDetector
-  apiDecider:
+    - Tomaj\NetteApi\Link\ApiLink
+    - Tomaj\NetteApi\Misc\IpDetector
+    apiDecider:
+        factory: Tomaj\NetteApi\ApiDecider
+        setup:
+            - addApi(\Tomaj\NetteApi\EndpointIdentifier('GET', 1, 'users'), \App\MyApi\v1\Handlers\UsersListingHandler(), \Tomaj\NetteApi\Authorization\NoAuthorization())
+            - addApi(\Tomaj\NetteApi\EndpointIdentifier('POST', 1, 'users', 'send-email'), \App\MyApi\v1\Handlers\SendEmailHandler(), \Tomaj\NetteApi\Authorization\BearerTokenAuthorization())
+
+```
+
+or lazy (preferred because of performance)
+```neon
+services:
+    - App\MyApi\v1\Handlers\SendEmailLazyHandler()
+    sendEmailLazyNamed: App\MyApi\v1\Handlers\SendEmailLazyNamedHandler()
+    
     factory: Tomaj\NetteApi\ApiDecider
     setup:
-      - addApi(\Tomaj\NetteApi\EndpointIdentifier('GET', 1, 'users'), \App\MyApi\v1\Handlers\UsersListingHandler(), \Tomaj\NetteApi\Authorization\NoAuthorization())
-      - addApi(\Tomaj\NetteApi\EndpointIdentifier('POST', 1, 'users', 'send-email'), \App\MyApi\v1\Handlers\SendEmailHandler(), \Tomaj\NetteApi\Authorization\BearerTokenAuthorization())
+      - addApi(\Tomaj\NetteApi\EndpointIdentifier('POST', 1, 'users', 'send-email-lazy'), 'App\MyApi\v1\Handlers\SendEmailHandler', \Tomaj\NetteApi\Authorization\BearerTokenAuthorization())
+      - addApi(\Tomaj\NetteApi\EndpointIdentifier('POST', 1, 'users', 'send-email-lazy-named'), '@sendEmailLazyNamed', \Tomaj\NetteApi\Authorization\BearerTokenAuthorization())
 ```
 
 As you can see in example, you can register as many endpoints as you want with different configurations. Nette-Api supports API versioning from the beginning.
@@ -328,6 +341,7 @@ services:
         setup:
             - addApi(\Tomaj\NetteApi\EndpointIdentifier('GET', 1, 'users'), \App\MyApi\v1\Handlers\UsersListingHandler(), \Tomaj\NetteApi\Authorization\BasicBasicAuthentication(['first-user': 'first-password', 'second-user': 'second-password']))
 ```
+
 
 ### Bearer token authentication
 For simple use of Bearer token authorization with few tokens, you can use [StaticTokenRepository](src/Misc/StaticTokenRepository.php) (Tomaj\NetteApi\Misc\StaticTokenRepository).

--- a/src/Api.php
+++ b/src/Api.php
@@ -19,9 +19,15 @@ class Api
 
     private $rateLimit;
 
+    /**
+     * @param EndpointInterface $endpoint
+     * @param ApiHandlerInterface|string $handler
+     * @param ApiAuthorizationInterface $authorization
+     * @param RateLimitInterface|null $rateLimit
+     */
     public function __construct(
         EndpointInterface $endpoint,
-        ApiHandlerInterface $handler,
+        $handler,
         ApiAuthorizationInterface $authorization,
         ?RateLimitInterface $rateLimit = null
     ) {
@@ -36,7 +42,10 @@ class Api
         return $this->endpoint;
     }
 
-    public function getHandler(): ApiHandlerInterface
+    /**
+     * @return ApiHandlerInterface|string
+     */
+    public function getHandler()
     {
         return $this->handler;
     }

--- a/src/ApiDecider.php
+++ b/src/ApiDecider.php
@@ -14,7 +14,7 @@ use Tomaj\NetteApi\Handlers\DefaultHandler;
 use Tomaj\NetteApi\RateLimit\RateLimitInterface;
 use Tomaj\NetteApi\Handlers\CorsPreflightHandlerInterface;
 
-final class ApiDecider
+class ApiDecider
 {
     /** @var Container */
     private $container;

--- a/src/ApiDecider.php
+++ b/src/ApiDecider.php
@@ -16,7 +16,8 @@ use Tomaj\NetteApi\Handlers\CorsPreflightHandlerInterface;
 
 final class ApiDecider
 {
-    private Container $container;
+    /** @var Container */
+    private $container;
 
     /** @var Api[] */
     private $apis = [];

--- a/tests/ApiDeciderTest.php
+++ b/tests/ApiDeciderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tomaj\NetteApi\Test\Params;
 
+use Nette\DI\Container;
 use PHPUnit\Framework\TestCase;
 use Tomaj\NetteApi\ApiDecider;
 use Tomaj\NetteApi\Authorization\NoAuthorization;
@@ -14,9 +15,18 @@ use Tomaj\NetteApi\Handlers\DefaultHandler;
 
 class ApiDeciderTest extends TestCase
 {
+    /** @var Container */
+    private $container;
+
+    protected function setUp(): void
+    {
+        $this->container = new Container();
+    }
+
     public function testDefaultHandlerWithNoRegisteredHandlers()
     {
-        $apiDecider = new ApiDecider();
+
+        $apiDecider = new ApiDecider($this->container);
         $result = $apiDecider->getApi('POST', '1', 'article', 'list');
 
         $this->assertInstanceOf(EndpointIdentifier::class, $result->getEndpoint());
@@ -26,7 +36,7 @@ class ApiDeciderTest extends TestCase
 
     public function testFindRightHandler()
     {
-        $apiDecider = new ApiDecider();
+        $apiDecider = new ApiDecider($this->container);
         $apiDecider->addApi(
             new EndpointIdentifier('POST', '2', 'comments', 'list'),
             new AlwaysOkHandler(),
@@ -47,7 +57,7 @@ class ApiDeciderTest extends TestCase
 
     public function testGetHandlers()
     {
-        $apiDecider = new ApiDecider();
+        $apiDecider = new ApiDecider($this->container);
 
         $this->assertEquals(0, count($apiDecider->getApis()));
 
@@ -62,7 +72,7 @@ class ApiDeciderTest extends TestCase
 
     public function testGlobalPreflight()
     {
-        $apiDecider = new ApiDecider();
+        $apiDecider = new ApiDecider($this->container);
         $apiDecider->enableGlobalPreflight();
 
         $this->assertEquals(0, count($apiDecider->getApis()));

--- a/tests/Handler/ApiListingHandlerTest.php
+++ b/tests/Handler/ApiListingHandlerTest.php
@@ -6,6 +6,7 @@ namespace Tomaj\NetteApi\Test\Handler;
 
 use Nette\Application\LinkGenerator;
 use Nette\Application\Routers\SimpleRouter;
+use Nette\DI\Container;
 use Nette\Http\UrlScript;
 use PHPUnit\Framework\TestCase;
 use Tomaj\NetteApi\ApiDecider;
@@ -18,12 +19,20 @@ use Tomaj\NetteApi\Link\ApiLink;
 
 class ApiListingHandlerTest extends TestCase
 {
+    /** @var Container */
+    private $container;
+
+    protected function setUp(): void
+    {
+        $this->container = new Container();
+    }
+
     public function testDefaultHandle()
     {
         $linkGenerator = new LinkGenerator(new SimpleRouter([]), new UrlScript('http://test/'));
         $apiLink = new ApiLink($linkGenerator);
 
-        $apiDecider = new ApiDecider();
+        $apiDecider = new ApiDecider($this->container);
         $apiDecider->addApi(
             new EndpointIdentifier('POST', '2', 'comments', 'list'),
             new AlwaysOkHandler(),
@@ -50,7 +59,7 @@ class ApiListingHandlerTest extends TestCase
         $linkGenerator = new LinkGenerator(new SimpleRouter([]), new UrlScript('http://test/'));
         $apiLink = new ApiLink($linkGenerator);
 
-        $apiDecider = new ApiDecider();
+        $apiDecider = new ApiDecider($this->container);
         $apiDecider->addApi(
             new EndpointIdentifier('POST', '1', 'comments', 'list'),
             new EchoHandler(),

--- a/tests/Handler/OpenApiHandlerTest.php
+++ b/tests/Handler/OpenApiHandlerTest.php
@@ -6,6 +6,7 @@ namespace Tomaj\NetteApi\Test\Handler;
 
 use Nette\Application\LinkGenerator;
 use Nette\Application\Routers\SimpleRouter;
+use Nette\DI\Container;
 use Nette\Http\UrlScript;
 use PHPUnit\Framework\TestCase;
 use Tomaj\NetteApi\ApiDecider;
@@ -17,13 +18,21 @@ use Nette\Http\Request;
 
 class OpenApiHandlerTest extends TestCase
 {
+    /** @var Container */
+    private $container;
+
+    protected function setUp(): void
+    {
+        $this->container = new Container();
+    }
+
     public function testHandlerWithMultipleResponseSchemas()
     {
         $linkGenerator = new LinkGenerator(new SimpleRouter([]), new UrlScript('http://test/'));
         $apiLink = new ApiLink($linkGenerator);
         $request = new Request(new UrlScript('http://test/'));
 
-        $apiDecider = new ApiDecider();
+        $apiDecider = new ApiDecider($this->container);
         $apiDecider->addApi(
             new EndpointIdentifier('GET', '1', 'test'),
             new MultipleOutputTestHandler(),

--- a/tests/Presenters/ApiPresenterTest.php
+++ b/tests/Presenters/ApiPresenterTest.php
@@ -24,9 +24,17 @@ use Tracy\Debugger;
 
 class ApiPresenterTest extends TestCase
 {
+    /** @var Container */
+    private $container;
+
+    protected function setUp(): void
+    {
+        $this->container = new Container();
+    }
+
     public function testSimpleResponse()
     {
-        $apiDecider = new ApiDecider();
+        $apiDecider = new ApiDecider($this->container);
         $apiDecider->addApi(new EndpointIdentifier('GET', '1', 'test', 'api'), new AlwaysOkHandler(), new NoAuthorization());
 
         $presenter = new ApiPresenter();
@@ -45,7 +53,7 @@ class ApiPresenterTest extends TestCase
 
     public function testWithAuthorization()
     {
-        $apiDecider = new ApiDecider();
+        $apiDecider = new ApiDecider($this->container);
         $apiDecider->addApi(
             new EndpointIdentifier('GET', '1', 'test', 'api'),
             new AlwaysOkHandler(),
@@ -66,7 +74,7 @@ class ApiPresenterTest extends TestCase
 
     public function testWithParams()
     {
-        $apiDecider = new ApiDecider();
+        $apiDecider = new ApiDecider($this->container);
         $apiDecider->addApi(
             new EndpointIdentifier('GET', '1', 'test', 'api'),
             new EchoHandler(),
@@ -95,7 +103,7 @@ class ApiPresenterTest extends TestCase
 
     public function testWithOutputs()
     {
-        $apiDecider = new ApiDecider();
+        $apiDecider = new ApiDecider($this->container);
         $apiDecider->addApi(
             new EndpointIdentifier('GET', '1', 'test', 'api'),
             new TestHandler(),


### PR DESCRIPTION
usage
```neon
services:
    someLazyHandler: SomeLazyHandler()
    apiDecider:
        setup:
            - addApi(Tomaj\NetteApi\EndpointIdentifier('POST', 3, 'app.init'), '@someLazyHandler', NoAuthorization())
```