### PR TITLE
Allow justinrainbow/json-schema to use v6 if necessary

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "tracy/tracy": "^2.6",
         "league/fractal": "~0.17",
         "tomaj/nette-bootstrap-form": "^2.0",
-        "justinrainbow/json-schema": "^5.2"
+        "justinrainbow/json-schema": "^5.2|^6.6"
     },
     "require-dev": {
         "nette/di": "^3.0",


### PR DESCRIPTION
The v6 is required by composer/composer library since v2.8.7 and causes dependency issues.

All recent releases of `composer/composer` were flagged as vulnerable. The fix is included in `v2.9.3` which requires `justinrainbow/json-schema` v6 which is incompatible with the current version of Nette API.

I've checked the v6 changes and they seem to be compatible for use in this library and therefore it should be OK to allow v5 OR v6 installation - see https://github.com/jsonrainbow/json-schema/releases/tag/6.0.0.

If possible, please cherry pick this also for v2 tag so that it could be used with 2.12 version.