### PR TITLE
Check authorization before input validation

### DIFF
--- a/src/Presenters/ApiPresenter.php
+++ b/src/Presenters/ApiPresenter.php
@@ -84,6 +84,11 @@ final class ApiPresenter implements IPresenter
             return $rateLimitResponse;
         }
 
+        $authResponse = $this->checkAuth($authorization, []);
+        if ($authResponse !== null) {
+            return $authResponse;
+        }
+
         $paramsProcessor = new ParamsProcessor($handler->params());
         if ($paramsProcessor->isError()) {
             $response = $this->errorHandler->handleInputParams($paramsProcessor->getErrors());
@@ -92,11 +97,6 @@ final class ApiPresenter implements IPresenter
         }
 
         $params = $paramsProcessor->getValues();
-
-        $authResponse = $this->checkAuth($authorization, $params);
-        if ($authResponse !== null) {
-            return $authResponse;
-        }
 
         try {
             $response = $handler->handle($params);


### PR DESCRIPTION
## Problem

In `ApiPresenter::run()`, input parameter validation is executed **before** authorization check:

https://github.com/tomaj/nette-api/blob/3.4.0/src/Presenters/ApiPresenter.php#L87-L99

```php
$paramsProcessor = new ParamsProcessor($handler->params());
if ($paramsProcessor->isError()) {
    return $this->errorHandler->handleInputParams(...);  // 400 wrong input
}

$params = $paramsProcessor->getValues();
$authResponse = $this->checkAuth($authorization, $params);  // auth runs later
```

This is a regression from v2.x where auth was checked first:
https://github.com/tomaj/nette-api/blob/2.13.0/src/Presenters/ApiPresenter.php#L73-L83

## Security impact

An unauthenticated client can probe API validation rules without providing a valid token. Requests with missing/invalid auth + invalid body return `400 wrong input` instead of `401`, leaking information about:

- which fields are required
- which validation rules apply
- the shape of the expected payload

Per OWASP ASVS 4.0.3 (V4.1.1 Access Control), authorization must be enforced before request processing.

## Suggested fix

Move `checkAuth()` before `ParamsProcessor` in `ApiPresenter::run()`.

## Version

`tomaj/nette-api` 3.4.0
